### PR TITLE
Refactor write_test common parts + add map tests.

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -13,7 +13,7 @@ func cborTestHarness(t *testing.T, in interface{}, expected []byte, marshaler fu
 	marshaler(in, &buf)
 
 	if bytes.Compare(buf.Bytes(), expected) != 0 {
-		t.Errorf("error writing %v: expected %v, got %v",
+		t.Errorf("error writing %v: expected [% X], got [% X]",
 			in, expected, buf.Bytes())
 	}
 }
@@ -79,6 +79,80 @@ func TestWriteArray(t *testing.T) {
 		m := func(in interface{}, out *bytes.Buffer) {
 			w := borat.NewCBORWriter(out)
 			w.WriteArray(in.([]interface{}))
+		}
+		cborTestHarness(t, testPatterns[i].value, testPatterns[i].cbor, m)
+	}
+}
+
+func TestWriteIntMap(t *testing.T) {
+	testPatterns := []struct {
+		value map[int]interface{}
+		cbor  []byte
+	}{
+		{
+			map[int]interface{}{
+				1: "Zürich",
+				2: "Confédération Suisse",
+			},
+			[]byte{
+				0xA2, 0x01, 0x67, 0x5A, 0xC3, 0xBC, 0x72, 0x69, 0x63,
+				0x68, 0x02, 0x76, 0x43, 0x6F, 0x6E, 0x66, 0xC3, 0xA9,
+				0x64, 0xC3, 0xA9, 0x72, 0x61, 0x74, 0x69, 0x6F, 0x6E,
+				0x20, 0x53, 0x75, 0x69, 0x73, 0x73, 0x65},
+		},
+		{
+			map[int]interface{}{
+				1: "AA",
+				2: 16,
+				3: -64,
+			},
+			[]byte{0xA3, 0x01, 0x62, 0x41, 0x41, 0x02, 0x10, 0x03, 0x38, 0x3F},
+		},
+	}
+
+	for i := range testPatterns {
+		m := func(in interface{}, out *bytes.Buffer) {
+			w := borat.NewCBORWriter(out)
+			w.WriteIntMap(in.(map[int]interface{}))
+		}
+		cborTestHarness(t, testPatterns[i].value, testPatterns[i].cbor, m)
+	}
+}
+
+func TestWriteStringMap(t *testing.T) {
+	testPatterns := []struct {
+		value map[string]interface{}
+		cbor  []byte
+	}{
+		{
+			map[string]interface{}{
+				"Zürich":      "CH",
+				"Seattle, WA": "USA",
+			},
+			[]byte{
+				0xA2, 0x6B, 0x53, 0x65, 0x61, 0x74, 0x74, 0x6C,
+				0x65, 0x2C, 0x20, 0x57, 0x41, 0x63, 0x55, 0x53,
+				0x41, 0x67, 0x5A, 0xC3, 0xBC, 0x72, 0x69, 0x63,
+				0x68, 0x62, 0x43, 0x48,
+			},
+		},
+		{
+			map[string]interface{}{
+				"a": "ABC",
+				"b": 64,
+				"c": -2,
+			},
+			[]byte{
+				0xA3, 0x61, 0x61, 0x63, 0x41, 0x42, 0x43, 0x61,
+				0x62, 0x18, 0x40, 0x61, 0x63, 0x21,
+			},
+		},
+	}
+
+	for i := range testPatterns {
+		m := func(in interface{}, out *bytes.Buffer) {
+			w := borat.NewCBORWriter(out)
+			w.WriteStringMap(in.(map[string]interface{}))
 		}
 		cborTestHarness(t, testPatterns[i].value, testPatterns[i].cbor, m)
 	}


### PR DESCRIPTION
There was a bit of repetitiveness in the tests comparing doing the same write /
compare. This change refactors that into a helper function.

Also added a case for integer slices, and tests for `map[string]interface{}`, `map[int]interface{}`