### PR TITLE
Make reader work

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -2,9 +2,9 @@ package borat
 
 import (
 	"bytes"
+	"math"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func cborDecoderHarness(t *testing.T, in []byte, expected interface{}) {
@@ -15,7 +15,14 @@ func cborDecoderHarness(t *testing.T, in []byte, expected interface{}) {
 		return
 	}
 	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Decoder returned unexpected result: want %v, got %v", expected, result)
+		t.Errorf("decoder returned unexpected result: want %v (%T), got %v (%T)", expected, expected, result, result)
+	}
+}
+
+func cborDecoderHarnessExpectErr(t *testing.T, in []byte, errExpect error) {
+	r := NewCBORReader(bytes.NewReader(in))
+	if _, err := r.Read(); err != errExpect {
+		t.Errorf("expected error %v but got %v", errExpect, err)
 	}
 }
 
@@ -64,25 +71,96 @@ func TestReadInt(t *testing.T) {
 			[]byte{0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			uint64(18446744073709551615),
 		},
+		{
+			[]byte{0x20},
+			-1,
+		},
+		{
+			[]byte{0x29},
+			-10,
+		},
+		{
+			[]byte{0x38, 0x63},
+			-100,
+		},
+		{
+			[]byte{0x39, 0x03, 0xe7},
+			-1000,
+		},
 	}
-
 	for i := range testPatterns {
 		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
 	}
 }
 
-func TestReadTime(t *testing.T) {
+// We do not support 16-bit floats at the moment. Test for expected functionality.
+func TestReadFloatUnsupported(t *testing.T) {
 	testPatterns := []struct {
-		cbor  []byte
-		value time.Time
+		cbor []byte
+		err  error
 	}{
 		{
-			[]byte{0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0},
-			time.Unix(1363896240, 0),
+			// 0.0
+			[]byte{0xf9, 0x00, 0x00},
+			UnsupportedTypeReadError,
+		},
+		{
+			// -0.0
+			[]byte{0xf9, 0x80, 0x00},
+			UnsupportedTypeReadError,
+		},
+		{
+			// 65504.0
+			[]byte{0xf9, 0x7b, 0xff},
+			UnsupportedTypeReadError,
 		},
 	}
+	for i := range testPatterns {
+		cborDecoderHarnessExpectErr(t, testPatterns[i].cbor, testPatterns[i].err)
+	}
+}
 
+// We only support IEEE754 single (32bit) or double (64bit) precision floats.
+func TestReadFloatSupported(t *testing.T) {
+	testPatterns := []struct {
+		cbor  []byte
+		value float64
+	}{
+		{
+			[]byte{0xfb, 0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a},
+			1.1,
+		},
+		{
+			[]byte{0xfa, 0x47, 0xc3, 0x50, 0x00},
+			100000.0,
+		},
+		{
+			[]byte{0xfa, 0x7f, 0x7f, 0xff, 0xff},
+			3.4028234663852886e+38,
+		},
+		{
+			[]byte{0xfb, 0x7e, 0x37, 0xe4, 0x3c, 0x88, 0x00, 0x75, 0x9c},
+			1.0e+300,
+		},
+		{
+			[]byte{0xfa, 0x7f, 0x80, 0x00, 0x00},
+			math.Inf(1),
+		},
+	}
 	for i := range testPatterns {
 		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+	}
+	// Manually test the NaN's since NaN != NaN.
+	nans := [][]byte{
+		[]byte{0xfa, 0x7f, 0xc0, 0x00, 0x00},
+		[]byte{0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+	}
+	for _, b := range nans {
+		r := NewCBORReader(bytes.NewReader(b))
+		if res, err := r.Read(); err != nil {
+			t.Errorf("expected no error decoding NaN but got: %v", err)
+		} else if !math.IsNaN(res.(float64)) {
+			t.Errorf("expected NaN but got %f decoding %v", res, b)
+		}
 	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,88 @@
+package borat
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func cborDecoderHarness(t *testing.T, in []byte, expected interface{}) {
+	r := NewCBORReader(bytes.NewReader(in))
+	result, err := r.Read()
+	if err != nil {
+		t.Errorf("failed to decode %v: want %v, got error: %v", expected, in, err)
+		return
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Decoder returned unexpected result: want %v, got %v", expected, result)
+	}
+}
+
+func TestReadInt(t *testing.T) {
+	testPatterns := []struct {
+		cbor  []byte
+		value interface{}
+	}{
+		{
+			[]byte{0x01},
+			uint64(1),
+		},
+		{
+			[]byte{0x0a},
+			uint64(10),
+		},
+		{
+			[]byte{0x17},
+			uint64(23),
+		},
+		{
+			[]byte{0x18, 0x18},
+			uint64(24),
+		},
+		{
+			[]byte{0x18, 0x19},
+			uint64(25),
+		},
+		{
+			[]byte{0x18, 0x64},
+			uint64(100),
+		},
+		{
+			[]byte{0x19, 0x03, 0xe8},
+			uint64(1000),
+		},
+		{
+			[]byte{0x1a, 0x00, 0x0f, 0x42, 0x40},
+			uint64(1000000),
+		},
+		{
+			[]byte{0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00},
+			uint64(1000000000000),
+		},
+		{
+			[]byte{0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			uint64(18446744073709551615),
+		},
+	}
+
+	for i := range testPatterns {
+		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+	}
+}
+
+func TestReadTime(t *testing.T) {
+	testPatterns := []struct {
+		cbor  []byte
+		value time.Time
+	}{
+		{
+			[]byte{0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0},
+			time.Unix(1363896240, 0),
+		},
+	}
+
+	for i := range testPatterns {
+		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+	}
+}

--- a/typeinf.go
+++ b/typeinf.go
@@ -21,4 +21,5 @@ const (
 	majorTag      = 0xc0
 	majorOther    = 0xe0
 	majorMask     = 0x1f
+	majorSelect   = 0xe0
 )

--- a/writer_test.go
+++ b/writer_test.go
@@ -3,6 +3,7 @@ package borat_test
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/britram/borat"
 )
@@ -153,6 +154,35 @@ func TestWriteStringMap(t *testing.T) {
 		m := func(in interface{}, out *bytes.Buffer) {
 			w := borat.NewCBORWriter(out)
 			w.WriteStringMap(in.(map[string]interface{}))
+		}
+		cborTestHarness(t, testPatterns[i].value, testPatterns[i].cbor, m)
+	}
+}
+
+func TestTime(t *testing.T) {
+	testPatterns := []struct {
+		value time.Time
+		cbor  []byte
+	}{
+		{
+			time.Unix(1519650657, 0),
+			[]byte{0xC1, 0x1A, 0x5A, 0x94, 0x07, 0x61},
+		},
+		{
+			time.Unix(-1519650657, 0),
+			[]byte{0xC1, 0x3A, 0x5A, 0x94, 0x07, 0x60},
+		},
+		{
+			time.Unix(0, 0),
+			[]byte{0xC1, 0x00},
+		},
+	}
+
+	// TODO: add tests for string based time format.
+	for i := range testPatterns {
+		m := func(in interface{}, out *bytes.Buffer) {
+			w := borat.NewCBORWriter(out)
+			w.WriteTime(in.(time.Time))
 		}
 		cborTestHarness(t, testPatterns[i].value, testPatterns[i].cbor, m)
 	}


### PR DESCRIPTION
There seemed to be some issues with using the reader, these commits start making the reader work for a subset of datatypes. So far tests have been added to verify that int, float, string, and map are working.

Note that trying to parse a float16 will return an `UnsupportedTypeReadError` because Go does not have builtin support for float16 and if we want to support that, some extra logic to encode and decode it will be required. It doesn't seem super important for RAINS to use float16 from what I've seen so far so maybe we leave that returning an error for now.

Not sure how `majorMask` was intended to be used before but I added a `majorSelect` to select the high order 3 bits (major type) and majorMask to select the low order 5 bits and worked from there to debug the rest of the reader.