### PR TITLE
Support tagged structs in interfaces.

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -21,6 +21,21 @@ func cborDecoderHarness(t *testing.T, in []byte, expected interface{}) {
 	}
 }
 
+func cborDecoderUntagMapHarness(t *testing.T, in []byte, expected interface{}) {
+	r := NewCBORReader(bytes.NewReader(in))
+	result, err := r.Read()
+	if err != nil {
+		t.Errorf("failed to decode %v: input % x, got error %v", expected, in, err)
+		return
+	}
+	if m, ok := result.(map[string]TaggedElement); ok {
+		result = r.UntagStringMap(m)
+	}
+	if diff, equal := messagediff.PrettyDiff(result, expected); !equal {
+		t.Errorf("decoder returned unexpected result: %#v diff=%s", result, diff)
+	}
+}
+
 func cborDecoderHarnessExpectErr(t *testing.T, in []byte, errExpect error) {
 	r := NewCBORReader(bytes.NewReader(in))
 	if _, err := r.Read(); err != errExpect {
@@ -246,7 +261,7 @@ func TestReadStringMap(t *testing.T) {
 		},
 	}
 	for i := range testPatterns {
-		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+		cborDecoderUntagMapHarness(t, testPatterns[i].cbor, testPatterns[i].value)
 	}
 }
 

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -14,7 +14,13 @@ type Indirector struct {
 	I int
 }
 
+type Indirector2 struct {
+	Something int
+}
+
 func (i Indirector) ConvolutedIndirection() int { return i.I }
+
+func (i Indirector2) ConvolutedIndirection() int { return i.Something }
 
 type One struct {
 	A uint64
@@ -35,20 +41,38 @@ func TestDirectInterface(t *testing.T) {
 	x = &Indirector{
 		I: 1,
 	}
+	var y ConvolutedIndirectable
+	y = &Indirector2{
+		Something: 123,
+	}
 	buf := bytes.NewBuffer([]byte{})
 	writer := NewCBORWriter(buf)
-	writer.RegisterCBORTag(1, Indirector{})
+	writer.RegisterCBORTag(CBORTag(1), Indirector{})
+	writer.RegisterCBORTag(CBORTag(2), Indirector2{})
 	reader := NewCBORReader(buf)
-	reader.RegisterCBORTag(1, Indirector{})
-	if err := writer.Marshal(x); err != nil {
-		t.Fatalf("failed to marshal interface type: %v", err)
-	}
+	reader.RegisterCBORTag(CBORTag(1), Indirector{})
+	reader.RegisterCBORTag(CBORTag(2), Indirector2{})
 	var r ConvolutedIndirectable
+	if err := writer.Marshal(x); err != nil {
+		t.Errorf("failed to marshal interface type %T: %v", x, err)
+		goto testY
+	}
 	if err := reader.Unmarshal(&r); err != nil {
-		t.Fatalf("failed to unmarshal interface type: %v", err)
+		t.Errorf("failed to unmarshal interface type: %v", err)
+		goto testY
 	}
 	if !reflect.DeepEqual(x, r) {
 		t.Errorf("got: %v, want %v", r, x)
+	}
+testY:
+	if err := writer.Marshal(y); err != nil {
+		t.Fatalf("failed to marshal interface type %T: %v", y, err)
+	}
+	if err := reader.Unmarshal(&r); err != nil {
+		t.Fatalf("failed to unmarshal interface type 2: %v", err)
+	}
+	if !reflect.DeepEqual(y, r) {
+		t.Errorf("got %v, want %v", r, y)
 	}
 }
 

--- a/structinf.go
+++ b/structinf.go
@@ -15,6 +15,12 @@ type structCBORSpec struct {
 	strKeyForField map[string]string
 }
 
+// TaggedElement is used to wrap elements which may be tagged for writing.
+type TaggedElement struct {
+	tag   CBORTag
+	value interface{}
+}
+
 func (scs *structCBORSpec) usingIntKeys() bool {
 	return scs.intKeyForField != nil
 }
@@ -113,12 +119,12 @@ func (scs *structCBORSpec) convertIntMapToStruct(in map[int]interface{}, out ref
 	}
 }
 
-func (scs *structCBORSpec) convertStructToStringMap(v reflect.Value) map[string]interface{} {
+func (scs *structCBORSpec) convertStructToStringMap(v reflect.Value, tagTypeMap map[reflect.Type]uint64) (map[string]TaggedElement, error) {
 	if scs.strKeyForField == nil {
 		panic(fmt.Sprintf("can't convert %s to string-keyed map", v.Type().Name()))
 	}
 
-	out := make(map[string]interface{})
+	out := make(map[string]TaggedElement)
 
 	for i, n := 0, v.NumField(); i < n; i++ {
 		fieldName := v.Type().Field(i).Name
@@ -126,17 +132,20 @@ func (scs *structCBORSpec) convertStructToStringMap(v reflect.Value) map[string]
 			continue
 		}
 		fieldVal := v.Field(i)
-		out[scs.strKeyForField[fieldName]] = fieldVal.Interface()
+		// Do not tag structs over here because Marshal does that.
+		elem := TaggedElement{}
+		elem.value = fieldVal.Interface()
+		out[scs.strKeyForField[fieldName]] = elem
 	}
 
-	return out
+	return out, nil
 }
 
 // handleSlice sets the field referenced by out to the data in in,
 // out should be a slice of some type and in should also be a []interface{}
-func (scs *structCBORSpec) handleSlice(out reflect.Value, in interface{}) {
+func (scs *structCBORSpec) handleSlice(out reflect.Value, in []interface{}, registry map[uint64]reflect.Type) {
 	if out.Kind() != reflect.Slice {
-		panic("called handleSlice on a non-slice")
+		panic("called nandleSlice on a non-slice")
 	}
 	k := out.Type().Elem().Kind()
 	if k == reflect.Ptr {
@@ -145,47 +154,47 @@ func (scs *structCBORSpec) handleSlice(out reflect.Value, in interface{}) {
 	// If the slice is a slice of pointers,
 	switch k {
 	case reflect.Uint64, reflect.String:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in {
 			out.Index(i).Set(reflect.ValueOf(e))
 		}
 	case reflect.Struct:
-		for i, e := range in.([]interface{}) {
-			scs.convertStringMapToStruct(e.(map[string]interface{}), out.Index(i))
+		for i, e := range in {
+			scs.convertStringMapToStruct(e.(map[string]TaggedElement), out.Index(i), registry)
 		}
 	case reflect.Slice:
-		inIter := in.([]interface{})
+		inIter := in
 		for i, inElem := range inIter {
 			slen := len(inElem.([]interface{}))
 			slice := reflect.MakeSlice(out.Type().Elem(), slen, slen)
 			out.Index(i).Set(slice)
-			scs.handleSlice(out.Index(i), inElem)
+			scs.handleSlice(out.Index(i), inElem.([]interface{}), registry)
 		}
 	default:
 		panic(fmt.Sprintf("unsupported slice type: %v", k))
 	}
 }
 
-func (scs *structCBORSpec) handleArray(out reflect.Value, in interface{}) {
+func (scs *structCBORSpec) handleArray(out reflect.Value, in TaggedElement) {
 	if out.Kind() != reflect.Array {
 		panic(fmt.Sprintf("called handleArray on non-array type: %v", out.Kind()))
 	}
 	switch out.Type().Elem().Kind() {
 	case reflect.Uint64, reflect.String:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			out.Index(i).Set(reflect.ValueOf(e))
 		}
 	case reflect.Uint32:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			dc := uint32(e.(uint64))
 			out.Index(i).Set(reflect.ValueOf(dc))
 		}
 	case reflect.Uint16:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			dc := uint16(e.(uint64))
 			out.Index(i).Set(reflect.ValueOf(dc))
 		}
 	case reflect.Uint8:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			dc := uint8(e.(uint64))
 			out.Index(i).Set(reflect.ValueOf(dc))
 		}
@@ -194,7 +203,9 @@ func (scs *structCBORSpec) handleArray(out reflect.Value, in interface{}) {
 	}
 }
 
-func (scs *structCBORSpec) convertStringMapToStruct(in map[string]interface{}, out reflect.Value) {
+// out must be a value of type struct. If the current thing is an interface then it should be
+// resolved to the actual type by the caller.
+func (scs *structCBORSpec) convertStringMapToStruct(in map[string]TaggedElement, out reflect.Value, registry map[uint64]reflect.Type) {
 	if scs.strKeyForField == nil {
 		panic(fmt.Sprintf("cant parse string map for struct type %s", out.Type().Name()))
 	}
@@ -211,27 +222,37 @@ func (scs *structCBORSpec) convertStringMapToStruct(in map[string]interface{}, o
 		fieldName := out.Type().Field(i).Name
 		mapIdx := scs.strKeyForField[fieldName]
 		// If this is a struct we should do something special here.
-		if value, ok := in[mapIdx]; ok {
+		if elem, ok := in[mapIdx]; ok {
 			// If this field is of type int but we have a uint64, we can cast
 			// it, provided that it fits.
-			if out.Field(i).Kind() == reflect.Int && reflect.ValueOf(value).Kind() == reflect.Uint64 {
-				value = int(value.(uint64))
+			if out.Field(i).Kind() == reflect.Int && reflect.ValueOf(elem.value).Kind() == reflect.Uint64 {
+				elem.value = int(elem.value.(uint64))
 			}
 			if out.Field(i).Kind() == reflect.Slice {
 				// We need to make a slice with the correct length and type.
-				slen := len(value.([]interface{}))
+				slen := len(elem.value.([]interface{}))
 				slice := reflect.MakeSlice(out.Field(i).Type(), slen, slen)
 				out.Field(i).Set(slice)
-				scs.handleSlice(out.Field(i), value) // Handle the elements of the slice.
+				scs.handleSlice(out.Field(i), elem.value.([]interface{}), registry) // Handle the elements of the slice.
 			} else if out.Field(i).Kind() == reflect.Array {
 				innerType := out.Field(i).Type().Elem()
-				arr := reflect.New(reflect.ArrayOf(len(value.([]interface{})), innerType)).Elem()
+				arr := reflect.New(reflect.ArrayOf(len(elem.value.([]interface{})), innerType)).Elem()
 				out.Field(i).Set(arr)
-				scs.handleArray(out.Field(i), value)
+				scs.handleArray(out.Field(i), elem)
 			} else if out.Field(i).Kind() == reflect.Struct {
-				scs.convertStringMapToStruct(value.(map[string]interface{}), out.Field(i))
+				scs.convertStringMapToStruct(elem.value.(map[string]TaggedElement), out.Field(i), registry)
+			} else if out.Field(i).Kind() == reflect.Interface {
+				concrete, ok := registry[uint64(elem.tag)]
+				if !ok {
+					panic(fmt.Sprintf("unsupported tag %d", elem.tag))
+				}
+				inst := reflect.New(concrete)
+				childScs := structCBORSpec{}
+				childScs.learnStruct(concrete)
+				childScs.convertStringMapToStruct(elem.value.(map[string]TaggedElement), inst.Elem(), registry)
+				out.Field(i).Set(inst)
 			} else {
-				out.Field(i).Set(reflect.ValueOf(value))
+				out.Field(i).Set(reflect.ValueOf(elem.value))
 			}
 		}
 	}


### PR DESCRIPTION
This commit finally adds support for interface types in structures which are
being unmarshaled. The user must first specify a mapping for all the structs
which are desired to be put in interface typed fields of structs which will be
marshaled, or directly marshaled with a variable of type &interface. This does
not yet support interface tagged structs in slices or arrays yet.