### PR TITLE
Add support for tagged structs

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -18,6 +18,8 @@ var (
 	UnsupportedTypeReadError = errors.New("unsupported type encountered in read")
 )
 
+// CBORReader provides functionality to decode encoded CBOR to structures or to
+// manually read elements out of a byte slice.
 type CBORReader struct {
 	in           io.Reader
 	pushback     byte
@@ -26,6 +28,7 @@ type CBORReader struct {
 	regTags      map[CBORTag]reflect.Type
 }
 
+// NewCBORReader creates a new instance of the CBORReader.
 func NewCBORReader(in io.Reader) *CBORReader {
 	r := new(CBORReader)
 	r.in = in
@@ -33,6 +36,7 @@ func NewCBORReader(in io.Reader) *CBORReader {
 	return r
 }
 
+// RegisterCBORTag configures a mapping from a CBOR tag to a specific struct.
 func (r *CBORReader) RegisterCBORTag(tag CBORTag, inst interface{}) error {
 	if k := reflect.TypeOf(inst).Kind(); k != reflect.Struct {
 		return fmt.Errorf("inst must be a struct, but got %v", k)
@@ -140,6 +144,7 @@ func (r *CBORReader) readBasicUnsigned(mt byte) (uint64, byte, bool, error) {
 	return u, ct, neg, nil
 }
 
+// ReadInt reads a numerical type and sets the sign accordingly.
 func (r *CBORReader) ReadInt() (int, error) {
 	var i int
 	u, _, neg, err := r.readBasicUnsigned(majorUnsigned)
@@ -157,6 +162,7 @@ func (r *CBORReader) ReadInt() (int, error) {
 	return i, nil
 }
 
+// ReadUint reads an numerical type but discards the sign information if any.
 func (r *CBORReader) ReadUint() (uint64, error) {
 	if u, _, _, err := r.readBasicUnsigned(majorUnsigned); err != nil {
 		return 0, err
@@ -165,6 +171,7 @@ func (r *CBORReader) ReadUint() (uint64, error) {
 	}
 }
 
+// ReadTag reads a CBOR tag type.
 func (r *CBORReader) ReadTag() (CBORTag, error) {
 	u, _, _, err := r.readBasicUnsigned(majorTag)
 	if err != nil {
@@ -174,6 +181,7 @@ func (r *CBORReader) ReadTag() (CBORTag, error) {
 	return CBORTag(u), nil
 }
 
+// ReadFloat reads a floating point type.
 func (r *CBORReader) ReadFloat() (float64, error) {
 	u, ct, _, err := r.readBasicUnsigned(majorOther)
 	if err != nil {
@@ -199,6 +207,7 @@ func (r *CBORReader) ReadFloat() (float64, error) {
 	return f, nil
 }
 
+// ReadBytes reads the byte array type.
 func (r *CBORReader) ReadBytes() ([]byte, error) {
 	// read length
 	u, _, _, err := r.readBasicUnsigned(majorBytes)
@@ -216,6 +225,7 @@ func (r *CBORReader) ReadBytes() ([]byte, error) {
 	return b, nil
 }
 
+// ReadString reads a string type.
 func (r *CBORReader) ReadString() (string, error) {
 	// read length
 	u, _, _, err := r.readBasicUnsigned(majorString)
@@ -238,7 +248,8 @@ func (r *CBORReader) ReadString() (string, error) {
 	return string(b), nil
 }
 
-func (r *CBORReader) ReadArray() ([]interface{}, error) {
+// ReadArray reads an arbitrary array type.
+func (r *CBORReader) ReadArray() ([]TaggedElement, error) {
 	// read length
 	u, _, _, err := r.readBasicUnsigned(majorArray)
 	if err != nil {
@@ -248,20 +259,33 @@ func (r *CBORReader) ReadArray() ([]interface{}, error) {
 	arraylen := int(u)
 
 	// create an output value
-	out := make([]interface{}, arraylen)
+	out := make([]TaggedElement, arraylen)
 
 	// now read that many values
 	for i := 0; i < arraylen; i++ {
+		var elem TaggedElement
 		v, err := r.Read()
 		if err != nil {
 			return nil, err
 		}
-		out[i] = v
+		if tag, ok := v.(CBORTag); ok {
+			// The thing we have read here is a CBOR tag, so we have to read again to get the tagged element.
+			te, err := r.Read()
+			if err != nil {
+				return nil, err
+			}
+			elem.Tag = tag
+			elem.Value = te
+		} else {
+			elem.Value = v
+		}
+		out[i] = elem
 	}
 
 	return out, nil
 }
 
+// ReadStringArray reads an array of strings.
 func (r *CBORReader) ReadStringArray() ([]string, error) {
 	// read length
 	u, _, _, err := r.readBasicUnsigned(majorArray)
@@ -286,6 +310,7 @@ func (r *CBORReader) ReadStringArray() ([]string, error) {
 	return out, nil
 }
 
+// ReadIntArray reads an array of integers.
 func (r *CBORReader) ReadIntArray() ([]int, error) {
 	// read length
 	u, _, _, err := r.readBasicUnsigned(majorArray)
@@ -365,6 +390,8 @@ func (r *CBORReader) UntagStringMap(in map[string]TaggedElement) map[string]inte
 	for k, v := range in {
 		if imap, ok := v.Value.(map[string]TaggedElement); ok {
 			out[k] = r.UntagStringMap(imap)
+		} else if iarr, ok := v.Value.([]TaggedElement); ok {
+			out[k] = r.UntagArray(iarr)
 		} else {
 			out[k] = v.Value
 		}
@@ -372,6 +399,21 @@ func (r *CBORReader) UntagStringMap(in map[string]TaggedElement) map[string]inte
 	return out
 }
 
+func (r *CBORReader) UntagArray(in []TaggedElement) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, v := range in {
+		if iarr, ok := v.Value.([]TaggedElement); ok {
+			out[i] = r.UntagArray(iarr)
+		} else if imap, ok := v.Value.(map[string]TaggedElement); ok {
+			out[i] = r.UntagStringMap(imap)
+		} else {
+			out[i] = v.Value
+		}
+	}
+	return out
+}
+
+// ReadIntMap reads an integer keyed map.
 func (r *CBORReader) ReadIntMap() (map[int]interface{}, error) {
 	// read length
 	u, _, _, err := r.readBasicUnsigned(majorArray)
@@ -402,6 +444,7 @@ func (r *CBORReader) ReadIntMap() (map[int]interface{}, error) {
 	return out, nil
 }
 
+// ReadTime reads a timestamp.
 func (r *CBORReader) ReadTime() (time.Time, error) {
 	// Case 1: the time is just a float, integer, or string.
 	// In this case we just treat it as if it were tagged.
@@ -422,9 +465,8 @@ func (r *CBORReader) ReadTime() (time.Time, error) {
 			secs := int64(whole)
 			ns := int64(frac * 10e9)
 			return time.Unix(secs, ns), nil
-		} else {
-			return time.Unix(0, 0), fmt.Errorf("got malformed majorOther type for timestamp: %x", ct)
 		}
+		return time.Unix(0, 0), fmt.Errorf("got malformed majorOther type for timestamp: %x", ct)
 	case majorNegative:
 		fallthrough
 	case majorUnsigned:
@@ -448,7 +490,7 @@ func (r *CBORReader) ReadTime() (time.Time, error) {
 	case majorTag:
 		break // Fall through to the tag logic below.
 	default:
-		return time.Unix(0, 0), fmt.Errorf("Unsupported tag for parsing time: %v", ct&majorMask)
+		return time.Unix(0, 0), fmt.Errorf("unsupported tag for parsing time: %v", ct&majorMask)
 	}
 	tag, err := r.ReadTag()
 	if err != nil {
@@ -498,10 +540,10 @@ func (r *CBORReader) ReadTime() (time.Time, error) {
 				return time.Unix(0, 0), fmt.Errorf("got malformed majorOther type for timestamp: %x", ct)
 			}
 		default:
-			return time.Unix(0, 0), fmt.Errorf("Timestamp not understood.")
+			return time.Unix(0, 0), fmt.Errorf("timestamp not understood")
 		}
 	default:
-		return time.Unix(0, 0), fmt.Errorf("Unrecognized time tag")
+		return time.Unix(0, 0), fmt.Errorf("unrecognized time tag")
 	}
 }
 
@@ -638,7 +680,7 @@ func (r *CBORReader) Unmarshal(x interface{}) error {
 			return nil
 		}
 	case reflect.Array:
-		return fmt.Errorf("Cannot unmarshal objects of type %v from CBOR", pv.Type().Elem())
+		return fmt.Errorf("cannot unmarshal objects of type %v from CBOR", pv.Type().Elem())
 	case reflect.Struct:
 		// treat times sepcially
 		if pv.Elem().Type() == reflect.TypeOf(time.Time{}) {
@@ -682,7 +724,7 @@ func (r *CBORReader) Unmarshal(x interface{}) error {
 		return nil
 	}
 
-	return fmt.Errorf("Cannot unmarshal objects of type %v from CBOR", pv.Type().Elem())
+	return fmt.Errorf("cannot unmarshal objects of type %v from CBOR", pv.Type().Elem())
 }
 
 // readReflectedStruct attempts to deserialize a map from the reader that
@@ -713,8 +755,7 @@ func (r *CBORReader) readReflectedStruct(pv reflect.Value) error {
 	case majorTag:
 		return errors.New("tagged structs are not supported yet")
 	}
-	scs.convertStringMapToStruct(m, pv, r.regTags)
-	return nil
+	return scs.convertStringMapToStruct(m, pv, r.regTags)
 }
 
 type CBORUnmarshaler interface {

--- a/reader.go
+++ b/reader.go
@@ -384,7 +384,8 @@ func (r *CBORReader) ReadStringMap() (map[string]TaggedElement, error) {
 }
 
 // UntagStringMap takes a map which contains optionally tagged elements and
-// removes the tags from the map and any nested maps recursively.
+// removes the tags from the map and any nested maps recursively. Also supports
+// nested arrays.
 func (r *CBORReader) UntagStringMap(in map[string]TaggedElement) map[string]interface{} {
 	out := make(map[string]interface{})
 	for k, v := range in {
@@ -399,6 +400,8 @@ func (r *CBORReader) UntagStringMap(in map[string]TaggedElement) map[string]inte
 	return out
 }
 
+// UntagArray takes an array containing optionally tagged elements and removes those
+// tags recursively. Also supports nested maps.
 func (r *CBORReader) UntagArray(in []TaggedElement) []interface{} {
 	out := make([]interface{}, len(in))
 	for i, v := range in {

--- a/reader_test.go
+++ b/reader_test.go
@@ -21,7 +21,7 @@ func cborDecoderHarness(t *testing.T, in []byte, expected interface{}) {
 	}
 }
 
-func cborDecoderUntagMapHarness(t *testing.T, in []byte, expected interface{}) {
+func cborDecoderUntagHarness(t *testing.T, in []byte, expected interface{}) {
 	r := NewCBORReader(bytes.NewReader(in))
 	result, err := r.Read()
 	if err != nil {
@@ -30,6 +30,8 @@ func cborDecoderUntagMapHarness(t *testing.T, in []byte, expected interface{}) {
 	}
 	if m, ok := result.(map[string]TaggedElement); ok {
 		result = r.UntagStringMap(m)
+	} else if a, ok := result.([]TaggedElement); ok {
+		result = r.UntagArray(a)
 	}
 	if diff, equal := messagediff.PrettyDiff(result, expected); !equal {
 		t.Errorf("decoder returned unexpected result: %#v diff=%s", result, diff)
@@ -228,7 +230,7 @@ func TestReadSlice(t *testing.T) {
 		},
 	}
 	for i := range testPatterns {
-		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+		cborDecoderUntagHarness(t, testPatterns[i].cbor, testPatterns[i].value)
 	}
 }
 
@@ -261,7 +263,7 @@ func TestReadStringMap(t *testing.T) {
 		},
 	}
 	for i := range testPatterns {
-		cborDecoderUntagMapHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+		cborDecoderUntagHarness(t, testPatterns[i].cbor, testPatterns[i].value)
 	}
 }
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -21,6 +21,21 @@ func cborDecoderHarness(t *testing.T, in []byte, expected interface{}) {
 	}
 }
 
+func cborDecoderUntagMapHarness(t *testing.T, in []byte, expected interface{}) {
+	r := NewCBORReader(bytes.NewReader(in))
+	result, err := r.Read()
+	if err != nil {
+		t.Errorf("failed to decode %v: input % x, got error %v", expected, in, err)
+		return
+	}
+	if m, ok := result.(map[string]TaggedElement); ok {
+		result = r.UntagStringMap(m)
+	}
+	if diff, equal := messagediff.PrettyDiff(result, expected); !equal {
+		t.Errorf("decoder returned unexpected result: %#v diff=%s", result, diff)
+	}
+}
+
 func cborDecoderHarnessExpectErr(t *testing.T, in []byte, errExpect error) {
 	r := NewCBORReader(bytes.NewReader(in))
 	if _, err := r.Read(); err != errExpect {
@@ -246,7 +261,7 @@ func TestReadStringMap(t *testing.T) {
 		},
 	}
 	for i := range testPatterns {
-		cborDecoderHarness(t, testPatterns[i].cbor, testPatterns[i].value)
+		cborDecoderUntagMapHarness(t, testPatterns[i].cbor, testPatterns[i].value)
 	}
 }
 

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -14,7 +14,13 @@ type Indirector struct {
 	I int
 }
 
+type Indirector2 struct {
+	Something int
+}
+
 func (i Indirector) ConvolutedIndirection() int { return i.I }
+
+func (i Indirector2) ConvolutedIndirection() int { return i.Something }
 
 type One struct {
 	A uint64
@@ -35,20 +41,38 @@ func TestDirectInterface(t *testing.T) {
 	x = &Indirector{
 		I: 1,
 	}
+	var y ConvolutedIndirectable
+	y = &Indirector2{
+		Something: 123,
+	}
 	buf := bytes.NewBuffer([]byte{})
 	writer := NewCBORWriter(buf)
-	writer.RegisterCBORTag(1, Indirector{})
+	writer.RegisterCBORTag(CBORTag(1), Indirector{})
+	writer.RegisterCBORTag(CBORTag(2), Indirector2{})
 	reader := NewCBORReader(buf)
-	reader.RegisterCBORTag(1, Indirector{})
-	if err := writer.Marshal(x); err != nil {
-		t.Fatalf("failed to marshal interface type: %v", err)
-	}
+	reader.RegisterCBORTag(CBORTag(1), Indirector{})
+	reader.RegisterCBORTag(CBORTag(2), Indirector2{})
 	var r ConvolutedIndirectable
+	if err := writer.Marshal(x); err != nil {
+		t.Errorf("failed to marshal interface type %T: %v", x, err)
+		goto testY
+	}
 	if err := reader.Unmarshal(&r); err != nil {
-		t.Fatalf("failed to unmarshal interface type: %v", err)
+		t.Errorf("failed to unmarshal interface type: %v", err)
+		goto testY
 	}
 	if !reflect.DeepEqual(x, r) {
 		t.Errorf("got: %v, want %v", r, x)
+	}
+testY:
+	if err := writer.Marshal(y); err != nil {
+		t.Fatalf("failed to marshal interface type %T: %v", y, err)
+	}
+	if err := reader.Unmarshal(&r); err != nil {
+		t.Fatalf("failed to unmarshal interface type 2: %v", err)
+	}
+	if !reflect.DeepEqual(y, r) {
+		t.Errorf("got %v, want %v", r, y)
 	}
 }
 

--- a/structinf.go
+++ b/structinf.go
@@ -15,6 +15,12 @@ type structCBORSpec struct {
 	strKeyForField map[string]string
 }
 
+// TaggedElement is used to wrap elements which may be tagged for writing.
+type TaggedElement struct {
+	tag   CBORTag
+	value interface{}
+}
+
 func (scs *structCBORSpec) usingIntKeys() bool {
 	return scs.intKeyForField != nil
 }
@@ -113,12 +119,12 @@ func (scs *structCBORSpec) convertIntMapToStruct(in map[int]interface{}, out ref
 	}
 }
 
-func (scs *structCBORSpec) convertStructToStringMap(v reflect.Value) map[string]interface{} {
+func (scs *structCBORSpec) convertStructToStringMap(v reflect.Value, tagTypeMap map[reflect.Type]uint64) (map[string]TaggedElement, error) {
 	if scs.strKeyForField == nil {
 		panic(fmt.Sprintf("can't convert %s to string-keyed map", v.Type().Name()))
 	}
 
-	out := make(map[string]interface{})
+	out := make(map[string]TaggedElement)
 
 	for i, n := 0, v.NumField(); i < n; i++ {
 		fieldName := v.Type().Field(i).Name
@@ -126,17 +132,20 @@ func (scs *structCBORSpec) convertStructToStringMap(v reflect.Value) map[string]
 			continue
 		}
 		fieldVal := v.Field(i)
-		out[scs.strKeyForField[fieldName]] = fieldVal.Interface()
+		// Do not tag structs over here because Marshal does that.
+		elem := TaggedElement{}
+		elem.value = fieldVal.Interface()
+		out[scs.strKeyForField[fieldName]] = elem
 	}
 
-	return out
+	return out, nil
 }
 
 // handleSlice sets the field referenced by out to the data in in,
 // out should be a slice of some type and in should also be a []interface{}
-func (scs *structCBORSpec) handleSlice(out reflect.Value, in interface{}) {
+func (scs *structCBORSpec) handleSlice(out reflect.Value, in []interface{}, registry map[uint64]reflect.Type) {
 	if out.Kind() != reflect.Slice {
-		panic("called handleSlice on a non-slice")
+		panic("called nandleSlice on a non-slice")
 	}
 	k := out.Type().Elem().Kind()
 	if k == reflect.Ptr {
@@ -145,47 +154,47 @@ func (scs *structCBORSpec) handleSlice(out reflect.Value, in interface{}) {
 	// If the slice is a slice of pointers,
 	switch k {
 	case reflect.Uint64, reflect.String:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in {
 			out.Index(i).Set(reflect.ValueOf(e))
 		}
 	case reflect.Struct:
-		for i, e := range in.([]interface{}) {
-			scs.convertStringMapToStruct(e.(map[string]interface{}), out.Index(i))
+		for i, e := range in {
+			scs.convertStringMapToStruct(e.(map[string]TaggedElement), out.Index(i), registry)
 		}
 	case reflect.Slice:
-		inIter := in.([]interface{})
+		inIter := in
 		for i, inElem := range inIter {
 			slen := len(inElem.([]interface{}))
 			slice := reflect.MakeSlice(out.Type().Elem(), slen, slen)
 			out.Index(i).Set(slice)
-			scs.handleSlice(out.Index(i), inElem)
+			scs.handleSlice(out.Index(i), inElem.([]interface{}), registry)
 		}
 	default:
 		panic(fmt.Sprintf("unsupported slice type: %v", k))
 	}
 }
 
-func (scs *structCBORSpec) handleArray(out reflect.Value, in interface{}) {
+func (scs *structCBORSpec) handleArray(out reflect.Value, in TaggedElement) {
 	if out.Kind() != reflect.Array {
 		panic(fmt.Sprintf("called handleArray on non-array type: %v", out.Kind()))
 	}
 	switch out.Type().Elem().Kind() {
 	case reflect.Uint64, reflect.String:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			out.Index(i).Set(reflect.ValueOf(e))
 		}
 	case reflect.Uint32:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			dc := uint32(e.(uint64))
 			out.Index(i).Set(reflect.ValueOf(dc))
 		}
 	case reflect.Uint16:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			dc := uint16(e.(uint64))
 			out.Index(i).Set(reflect.ValueOf(dc))
 		}
 	case reflect.Uint8:
-		for i, e := range in.([]interface{}) {
+		for i, e := range in.value.([]interface{}) {
 			dc := uint8(e.(uint64))
 			out.Index(i).Set(reflect.ValueOf(dc))
 		}
@@ -194,7 +203,9 @@ func (scs *structCBORSpec) handleArray(out reflect.Value, in interface{}) {
 	}
 }
 
-func (scs *structCBORSpec) convertStringMapToStruct(in map[string]interface{}, out reflect.Value) {
+// out must be a value of type struct. If the current thing is an interface then it should be
+// resolved to the actual type by the caller.
+func (scs *structCBORSpec) convertStringMapToStruct(in map[string]TaggedElement, out reflect.Value, registry map[uint64]reflect.Type) {
 	if scs.strKeyForField == nil {
 		panic(fmt.Sprintf("cant parse string map for struct type %s", out.Type().Name()))
 	}
@@ -211,27 +222,37 @@ func (scs *structCBORSpec) convertStringMapToStruct(in map[string]interface{}, o
 		fieldName := out.Type().Field(i).Name
 		mapIdx := scs.strKeyForField[fieldName]
 		// If this is a struct we should do something special here.
-		if value, ok := in[mapIdx]; ok {
+		if elem, ok := in[mapIdx]; ok {
 			// If this field is of type int but we have a uint64, we can cast
 			// it, provided that it fits.
-			if out.Field(i).Kind() == reflect.Int && reflect.ValueOf(value).Kind() == reflect.Uint64 {
-				value = int(value.(uint64))
+			if out.Field(i).Kind() == reflect.Int && reflect.ValueOf(elem.value).Kind() == reflect.Uint64 {
+				elem.value = int(elem.value.(uint64))
 			}
 			if out.Field(i).Kind() == reflect.Slice {
 				// We need to make a slice with the correct length and type.
-				slen := len(value.([]interface{}))
+				slen := len(elem.value.([]interface{}))
 				slice := reflect.MakeSlice(out.Field(i).Type(), slen, slen)
 				out.Field(i).Set(slice)
-				scs.handleSlice(out.Field(i), value) // Handle the elements of the slice.
+				scs.handleSlice(out.Field(i), elem.value.([]interface{}), registry) // Handle the elements of the slice.
 			} else if out.Field(i).Kind() == reflect.Array {
 				innerType := out.Field(i).Type().Elem()
-				arr := reflect.New(reflect.ArrayOf(len(value.([]interface{})), innerType)).Elem()
+				arr := reflect.New(reflect.ArrayOf(len(elem.value.([]interface{})), innerType)).Elem()
 				out.Field(i).Set(arr)
-				scs.handleArray(out.Field(i), value)
+				scs.handleArray(out.Field(i), elem)
 			} else if out.Field(i).Kind() == reflect.Struct {
-				scs.convertStringMapToStruct(value.(map[string]interface{}), out.Field(i))
+				scs.convertStringMapToStruct(elem.value.(map[string]TaggedElement), out.Field(i), registry)
+			} else if out.Field(i).Kind() == reflect.Interface {
+				concrete, ok := registry[uint64(elem.tag)]
+				if !ok {
+					panic(fmt.Sprintf("unsupported tag %d", elem.tag))
+				}
+				inst := reflect.New(concrete)
+				childScs := structCBORSpec{}
+				childScs.learnStruct(concrete)
+				childScs.convertStringMapToStruct(elem.value.(map[string]TaggedElement), inst.Elem(), registry)
+				out.Field(i).Set(inst)
 			} else {
-				out.Field(i).Set(reflect.ValueOf(value))
+				out.Field(i).Set(reflect.ValueOf(elem.value))
 			}
 		}
 	}

--- a/writer.go
+++ b/writer.go
@@ -10,11 +10,15 @@ import (
 	"time"
 )
 
+// DateTimePref indicates the format for marshaling timestamps.
 type DateTimePref int
 
 const (
+	// DateTimePrefInt causes a timestamp to be encoded as an int.
 	DateTimePrefInt = iota
+	// DateTimePrefFloat causes a timestamp to be encoded as a float.
 	DateTimePrefFloat
+	// DateTimePrefString causes a timestamp to be encoded as a String.
 	DateTimePrefString
 )
 
@@ -133,6 +137,7 @@ func (w *CBORWriter) WriteBool(b bool) error {
 	return err
 }
 
+// WriteTime writes a time value to the output stream.
 func (w *CBORWriter) WriteTime(t time.Time) error {
 	switch w.dateTimePref {
 	case DateTimePrefInt:


### PR DESCRIPTION
Cleaned up the edge cases to properly support tagged elements in arrays and
maps. Now the array and map methods return a tagged type, which can be untagged
by calling the appropriate method. Maps containing arrays and arrays containing
maps will be cross-untagged.

Modified the tests to untag the results of the read calls so that they can be
compared to the input structures.

Implemented interface setting on inner structs which are containined in slices.
At the moment it will set an interface slice to a slice of the concrete struct,
but it would also be possible to make a tunable option to choose between
setting a pointer and setting the concrete value in the interface.