### PR TITLE
Complete support for RainsMessage

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -38,9 +38,6 @@ func NewCBORReader(in io.Reader) *CBORReader {
 
 // RegisterCBORTag configures a mapping from a CBOR tag to a specific struct.
 func (r *CBORReader) RegisterCBORTag(tag CBORTag, inst interface{}) error {
-	if k := reflect.TypeOf(inst).Kind(); k != reflect.Struct {
-		return fmt.Errorf("inst must be a struct, but got %v", k)
-	}
 	if _, ok := r.regTags[tag]; ok {
 		return fmt.Errorf("tag %d is already registered", tag)
 	}

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -90,19 +90,21 @@ func TestRoundtripStructs(t *testing.T) {
 		D: []string{"Lorem", "Ipsum"},
 		E: []Two{Two{"First"}, Two{"Second"}, Two{"Third"}},
 		F: []*Two{&Two{"Stuff"}},
-		G: &Indirector{1},
+		G: Indirector{1},
 		H: []ConvolutedIndirectable{&Indirector{21}, &Indirector{31}},
 		I: IntTypedef(32),
 	}
 	buf := bytes.NewBuffer([]byte{})
 	writer := NewCBORWriter(buf)
 	writer.RegisterCBORTag(0xaa, Two{})
-	writer.RegisterCBORTag(0xbb, Indirector{})
+	writer.RegisterCBORTag(0xbb, &Indirector{})
 	writer.RegisterCBORTag(0xcc, uint8(0))
+	writer.RegisterCBORTag(0xdd, Indirector{})
 	reader := NewCBORReader(buf)
 	reader.RegisterCBORTag(0xaa, Two{})
-	reader.RegisterCBORTag(0xbb, Indirector{})
+	reader.RegisterCBORTag(0xbb, &Indirector{})
 	reader.RegisterCBORTag(0xcc, uint8(0))
+	reader.RegisterCBORTag(0xdd, Indirector{})
 	if err := writer.Marshal(s); err != nil {
 		t.Errorf("Marshal failed: %v", err)
 	}

--- a/writer.go
+++ b/writer.go
@@ -168,30 +168,7 @@ func (w *CBORWriter) WriteArray(a []interface{}) error {
 		return err
 	}
 
-	writeTags := false
-	outer := reflect.ValueOf(a).Type()
-	oKind := outer.Kind()
-	if oKind != reflect.Array && oKind != reflect.Slice {
-		return fmt.Errorf("unspoorted argument: want only array or slice but got %v", oKind)
-	}
-	iKind := outer.Elem().Kind()
-	if iKind == reflect.Interface {
-		writeTags = true
-	}
-
 	for i := range a {
-		if writeTags {
-			iType := reflect.ValueOf(a[i]).Type()
-			if iType.Kind() == reflect.Ptr {
-				iType = iType.Elem()
-			}
-			if _, ok := w.regTags[iType]; !ok {
-				return fmt.Errorf("the type %v was not found in the tag registry", iType)
-			}
-			// Note that we don't actually write the tag here because marshal will do it
-			// for us, but we still have to check here whether the tag is there or not
-			// because marshal does not know if it is an interface slice we here or not.
-		}
 		if err := w.Marshal(a[i]); err != nil {
 			return err
 		}

--- a/writer_test.go
+++ b/writer_test.go
@@ -79,7 +79,9 @@ func TestWriteArray(t *testing.T) {
 	for i := range testPatterns {
 		m := func(in interface{}, out *bytes.Buffer) {
 			w := borat.NewCBORWriter(out)
-			w.WriteArray(in.([]interface{}))
+			if err := w.WriteArray(in.([]interface{})); err != nil {
+				t.Errorf("writeArray failed: %v", err)
+			}
 		}
 		cborTestHarness(t, testPatterns[i].value, testPatterns[i].cbor, m)
 	}


### PR DESCRIPTION
All functionality for encoding a sample RainsMessage type is now implemented and a test from rainspub to rainsd is able to correctly send some zones over.